### PR TITLE
Add setInterval

### DIFF
--- a/TimedEvent/TimedEvent.cpp
+++ b/TimedEvent/TimedEvent.cpp
@@ -107,5 +107,10 @@ void TimedEventClass::stop(short eventId) {
 	}
 }
 
+void TimedEventClass::setInterval(short eventId, unsigned long intervalMillis) {
+	if (this->findTimer(eventId)) {
+		this->currentTimer->intervalMillis = intervalMillis;
+	}
+}
 
 TimedEventClass TimedEvent;

--- a/TimedEvent/TimedEvent.h
+++ b/TimedEvent/TimedEvent.h
@@ -53,6 +53,7 @@ class TimedEventClass
     TimedEventClass();
 	void addTimer(short eventId, unsigned long intervalMillis, void (*onEvent)(TimerInformation* Sender));
 	void addTimer(unsigned long intervalMillis, void (*onEvent)(TimerInformation* Sender));
+	void setInterval(short eventId, unsigned long intervalMillis);
 	void start(short eventId);
 	void stop(short eventId);
 	void loop();

--- a/TimedEvent/keywords.txt
+++ b/TimedEvent/keywords.txt
@@ -5,3 +5,4 @@ addTimer	KEYWORD2
 start	KEYWORD2
 stop	KEYWORD2
 loop	KEYWORD2
+setInterval	KEYWORD2


### PR DESCRIPTION
Add setInterval, to allow timers to be reused with a different interval value. This is necessary because timers with obsolete interval values cannot be destroyed.
