### PR TITLE
Add Stream support to AdvancedSerial

### DIFF
--- a/AdvancedSerial/AdvancedSerial.h
+++ b/AdvancedSerial/AdvancedSerial.h
@@ -64,7 +64,7 @@ struct AdvancedSerialMessage {
 class AdvancedSerialClass
 {
   public:
-    AdvancedSerialClass();
+	AdvancedSerialClass(Stream& stream = Serial );
 	void setReceiver(void (*onReceive)(AdvancedSerialMessage* Message));
 	void send(byte id, byte size, byte* payload);
 	void loop();
@@ -74,6 +74,7 @@ class AdvancedSerialClass
 	byte bufferPosition;
 	byte messageBuffer[sizeof(AdvancedSerialMessage)+MESSAGE_MAX_PAYLOAD_SIZE];
 	AdvancedSerialMessage* message;
+	Stream& serialStream;
 	void (*onReceive)(AdvancedSerialMessage* Message);
 	void send(byte type, byte id, byte size, byte* payload);
 

--- a/AdvancedSerial/examples/Temperature/DisplayTemp.ino
+++ b/AdvancedSerial/examples/Temperature/DisplayTemp.ino
@@ -1,0 +1,42 @@
+#include <SoftwareSerial.h>
+#include <AdvancedSerial.h>
+
+SoftwareSerial comms = SoftwareSerial(2,4);
+AdvancedSerialClass Ser( comms );
+
+struct {
+  uint32_t  millis;
+  uint16_t  value;
+} temperaturePayload;
+
+typedef enum {
+  MSG_TEMPERATURE,
+  MSG_HEATER_BUTTON  
+} Messages;
+
+void setup() {
+  Serial.begin( 115200 );
+  comms.begin( 19200 );
+
+  Ser.setReceiver( onMessage );
+}
+
+void loop() {
+  Ser.loop();
+}
+
+void onMessage( AdvancedSerialMessage* message ){
+  switch ( message->id ){
+    case MSG_TEMPERATURE:
+      memcpy( &temperaturePayload, message->payload, message->size );
+      Serial.print( temperaturePayload.millis );
+      Serial.print( F(" temp=") );
+      Serial.println( temperaturePayload.value );
+      break;
+    case MSG_HEATER_BUTTON:
+      // handle this message
+      break;
+  }
+}
+
+

--- a/AdvancedSerial/examples/Temperature/ReadTemp.ino
+++ b/AdvancedSerial/examples/Temperature/ReadTemp.ino
@@ -1,0 +1,35 @@
+#include <SoftwareSerial.h>
+#include <AdvancedSerial.h>
+
+#define READ_FROM   A0
+
+
+SoftwareSerial comms = SoftwareSerial(2,4);
+AdvancedSerialClass Ser( comms );
+
+struct {
+  uint32_t  millis;
+  uint16_t  value;
+} temperaturePayload;
+
+typedef enum {
+  MSG_TEMPERATURE,
+  MSG_HEATER_BUTTON  
+} Messages;
+
+void setup() {
+  Serial.begin( 115200 );
+  comms.begin( 19200 );
+  
+}
+
+void loop() {
+  temperaturePayload.value = analogRead( READ_FROM );
+  temperaturePayload.millis = millis();
+
+  Serial.println( temperaturePayload.value );
+  
+  Ser.send( MSG_TEMPERATURE, sizeof( temperaturePayload ), (byte*) &temperaturePayload );
+  Ser.loop();
+  delay( 1000 );
+}


### PR DESCRIPTION
Allows AdvancedSerialClass to accept an optional argument of a Stream reference on its constructor to create a different instance which can be used with different Streams. This include any of the HardwareSerial instances such as Serial1, Serial2 and Serial3, as well as being able to use SoftwareSerial.

An AdvancedSerial object is already created at the end of AdvancedSerial.cpp in the original code, so I did not feel comfortable removing it as this would break backwards compatibility. It is unfortunate if you want to use AdvancedSerial with any other Stream that is not Serial, you still have the RAM used by the unused AdvancedSerial object (about 43 bytes). Also, the user needs to instantiate an appropriate AdvancedSerialClass object in their sketch, so the feel is different because a Serial based AdvancedSerialClass and one that is not based on Serial.
